### PR TITLE
Enable sending additional values, add other speed consts

### DIFF
--- a/src/Pingen.php
+++ b/src/Pingen.php
@@ -76,6 +76,12 @@ class Pingen
      * @constant string Sending speed economy
      */
     const SPEED_ECONOMY = 2;
+    
+    const SPEED_EINSCHREIBEN = 3;
+    
+    const SPEED_A_POST_PLUS = 4;
+    
+    const SPEED_B2_POST = 5;
 
     /**
      * @var string Base URL of Pingen API
@@ -206,11 +212,15 @@ class Pingen
      * @param int $iSpeed
      * @param int $iColor
 	 * @param int $iEnvelopeId
+	 * @param array $aValues
      * @return object
      */
-    public function document_upload($sFile, $iSend = false, $iSpeed = self::SPEED_PRIORITY, $iColor = self::PRINT_COLOR, $iEnvelopeId = null)
+    public function document_upload($sFile, $iSend = false, $iSpeed = self::SPEED_PRIORITY, $iColor = self::PRINT_COLOR, $iEnvelopeId = null, $aValues = [])
     {
         $aOptions = array('send' => (boolean)$iSend, 'speed' => $iSpeed, 'color' => $iColor, 'envelope' => $iEnvelopeId);
+        if (empty($aValues) === false) {
+            $aOptions['values'] = $aValues;
+        }
         return $this->execute('document/upload', $aOptions, $sFile);
     }
 


### PR DESCRIPTION
This change allows us to use "A Post-Plus" delivery speed.

- Constants names are only a suggestion
- It optionally passes extra data "values" to `/document/upload` endpoint, what is theoretically undocumented behaviour, but works the same as doing it through `/document/send` - it would be very helpful to hear if it was supposed to work this way, or if it's only a bug