### PR TITLE
Raise timeout

### DIFF
--- a/src/Pingen.php
+++ b/src/Pingen.php
@@ -657,7 +657,7 @@ class Pingen
         curl_setopt($objCurlConn, CURLOPT_POST, 1);
         curl_setopt($objCurlConn, CURLOPT_POSTFIELDS, $aData);
         curl_setopt($objCurlConn, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($objCurlConn, CURLOPT_CONNECTTIMEOUT, 3); 
+        curl_setopt($objCurlConn, CURLOPT_CONNECTTIMEOUT, 10);
         curl_setopt($objCurlConn, CURLOPT_TIMEOUT, 60);
 
         /*


### PR DESCRIPTION
I got reports that for some users, when the api hostname was not cached, it took longer than 3 seconds to resolve, leading to failures.
The culprit is the CURLOPT_CONNECTTIMEOUT option, which is set to 3. The default PHP value is 300. I raised this to 10 seconds as it should be enough to mitigate the issue.